### PR TITLE
Checksum and fields

### DIFF
--- a/examples/frame-decode.rs
+++ b/examples/frame-decode.rs
@@ -120,6 +120,12 @@ fn main() -> Result<(), Error> {
                                             println!("      {}", data);
                                         }
                                     }
+                                    DataType::MagneticField => {
+                                        if matches!(data_id.precision(), Precision::Float32) {
+                                            let data = MagneticField::<f32>::from_be_slice(pkt.payload())?;
+                                            println!("      {}", data);
+                                        }
+                                    }
                                     DataType::AltitudeEllipsoid => {
                                         if matches!(data_id.precision(), Precision::Float64) {
                                             let data = AltitudeEllipsoid::<f64>::from_be_slice(

--- a/src/mtdata2/magnetic_field.rs
+++ b/src/mtdata2/magnetic_field.rs
@@ -1,0 +1,21 @@
+use crate::precision::PrecisionExt;
+use core::fmt;
+
+/// Contains the calibrated MagneticField vector in x, y, and z axes in a.u.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct MagneticField<T: PrecisionExt> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+}
+
+impl<T: PrecisionExt> fmt::Display for MagneticField<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "X({:.3}), Y({:.3}), Z({:.3})", self.x, self.y, self.z)
+    }
+}
+
+precision_float32_3field_wire_impl!(MagneticField, x, y, z);
+precision_float64_3field_wire_impl!(MagneticField, x, y, z);
+precision_fp1220_3field_wire_impl!(MagneticField, x, y, z);
+precision_fp1632_3field_wire_impl!(MagneticField, x, y, z);

--- a/src/mtdata2/mod.rs
+++ b/src/mtdata2/mod.rs
@@ -1,4 +1,5 @@
 pub mod acceleration;
+pub mod magnetic_field;
 pub mod altitude_ellipsoid;
 pub mod euler_angles;
 pub mod lat_lon;
@@ -12,6 +13,7 @@ pub mod utc_time;
 pub mod velocity_xyz;
 
 pub use acceleration::*;
+pub use magnetic_field::*;
 pub use altitude_ellipsoid::*;
 pub use euler_angles::*;
 pub use lat_lon::*;

--- a/src/wire/data_id.rs
+++ b/src/wire/data_id.rs
@@ -75,7 +75,7 @@ impl Default for CoordinateSystem {
 enum_with_unknown! {
     pub enum DataType(u16) {
         // TemperatureGroup     = 0x08x0
-        Temperature             = 0x0810,
+        Temperature             = 0x0810, // degrees Celsius
 
         // TimestampGroup       = 0x10x0
         UtcTime                 = 0x1010,
@@ -85,18 +85,31 @@ enum_with_unknown! {
 
         // OrientationGroup     = 0x20xy
         Quaternion              = 0x2010,
-        EulerAngles             = 0x2030,
+        EulerAngles             = 0x2030, // degrees
 
         // AccelerationGroup    = 0x40xy
-        Acceleration            = 0x4020,
+        DeltaV                  = 0x4010, // m/s
+        Acceleration            = 0x4020, // m/s^2
+        FreeAcceleration        = 0x4030, // m/s^2
+        AccelerationHR          = 0x4040, // m/s^2
 
         // PositionGroup        = 0x50xy
-        AltitudeEllipsoid       = 0x5020,
-        PositionEcef            = 0x5030,
-        LatLon                  = 0x5040,
+        AltitudeEllipsoid       = 0x5020, // meters
+        PositionEcef            = 0x5030, // meters
+        LatLon                  = 0x5040, // degrees
+
+        // GnssGroup            = 0x70x0
+        GnssPvtData             = 0x7010,
+        GnssSatInfo             = 0x7020,
+        GnssPvtPulse            = 0x7030, // seconds
 
         // AngularVelocityGroup = 0x80xy
-        RateOfTurn              = 0x8020,
+        RateOfTurn              = 0x8020, // rad/s
+        DeltaQ                  = 0x8030,
+        RateOfTurnHr            = 0x8040, // rad/s
+
+        // MagneticGroup        = 0xC0xy
+        MagneticField           = 0xC020, // a.u. (atomic units)
 
         // VelocityGroup        = 0xD0xy
         VelocityXYZ             = 0xD010,
@@ -104,6 +117,8 @@ enum_with_unknown! {
         // StatusGroup          = 0xE0x0
         StatusByte              = 0xE010,
         StatusWord              = 0xE020,
+        DeviceId                = 0xE080,
+        LocationId              = 0xE090,
     }
 }
 


### PR DESCRIPTION
A small PR for
* adding method for filing appropriate frame checksum. I was having trouble with this as Frame mutably borrows the buffer and doesn't provide access to the required fields to compute the checksum external to the library. As far as I can tell, I would otherwise have to release the frame, compute the checksum manually, then create the frame again to write the checksum. Let me know if I am missing something! The existing checksum method confused me, because it includes the checksum byte in the calculation, and so wasn't useful for frame construction.
* Add field more datatypes to the DataType enum and add a corresponding MagneticField data struct.

In addition to this, I wrote some small code to use this library with rsusb which should work with the CA-USB-MTi USB cable on all platforms where rsusb works (including macos where Mti does not provide drivers and it is not enumerated as a tty). Let me know if you might be interested in that as a second example alongside your tty example.